### PR TITLE
feat: drop allUsers iam policies and remove Private Workers Pool need

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Functional examples are included in the
 | database\_user | Database user name. | `string` | `"crmintapp"` | no |
 | frontend\_image | Docker image uri (with tag) for the frontend service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"` | no |
 | goog\_bc\_deployment\_name | This is only set if run via BC/CM | `string` | `""` | no |
-| iap\_allowed\_users | n/a | `list(string)` | n/a | yes |
+| iap\_allowed\_users | List of user email addresses that should be allowed to use the CRMint UI | `list(string)` | n/a | yes |
 | iap\_brand\_id | Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`). | `string` | `null` | no |
 | iap\_support\_email | Support email used for configuring IAP | `string` | n/a | yes |
 | jobs\_image | Docker image uri (with tag) for the jobs service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"` | no |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ module "crmint" {
   # Google Cloud Platform.
   project_id                = "YOUR_PROJECT_ID"
   region                    = "GCP_REGION"  # e.g. us-east1
-  zone                      = "GCP_ZONE"  # e.g. us-east1-c
   database_instance_name    = "crmint-3-db"
   use_vpc                   = true
 

--- a/README.md
+++ b/README.md
@@ -78,21 +78,21 @@ Functional examples are included in the
 | database\_availability\_type | Database availability type. Defaults to one zone. | `string` | `"ZONAL"` | no |
 | database\_instance\_name | Name for the Cloud SQL instance. | `string` | `"crmint-3-db"` | no |
 | database\_name | Name of the database in your Cloud SQL instance. | `string` | `"crmintapp-db"` | no |
-| database\_project\_id | Database GCP project to use. Defaults to `var.project_id`. | `any` | `null` | no |
-| database\_region | Database region to setup a Cloud SQL instance. Defaults to `var.region` | `any` | `null` | no |
+| database\_project\_id | Database GCP project to use. Defaults to `var.project_id`. | `string` | `null` | no |
+| database\_region | Database region to setup a Cloud SQL instance. Defaults to `var.region` | `string` | `null` | no |
 | database\_tier | Database instance machine tier. Defaults to a small instance. | `string` | `"db-g1-small"` | no |
 | database\_user | Database user name. | `string` | `"crmintapp"` | no |
 | frontend\_image | Docker image uri (with tag) for the frontend service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"` | no |
 | goog\_bc\_deployment\_name | This is only set if run via BC/CM | `string` | `""` | no |
-| iap\_allowed\_users | n/a | `list(any)` | n/a | yes |
-| iap\_brand\_id | Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`). | `any` | `null` | no |
-| iap\_support\_email | Support email used for configuring IAP | `any` | n/a | yes |
+| iap\_allowed\_users | n/a | `list(string)` | n/a | yes |
+| iap\_brand\_id | Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`). | `string` | `null` | no |
+| iap\_support\_email | Support email used for configuring IAP | `string` | n/a | yes |
 | jobs\_image | Docker image uri (with tag) for the jobs service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"` | no |
 | labels | A set of key/value label pairs to assign to the resources deployed by this blueprint. | `map(string)` | `{}` | no |
-| network\_project\_id | Network GCP project to use. Defaults to `var.project_id`. | `any` | `null` | no |
-| network\_region | Network region. Defaults to `var.region`. | `any` | `null` | no |
-| notification\_sender\_email | Email address to send notifications to. | `any` | n/a | yes |
-| project\_id | GCP Project ID | `any` | n/a | yes |
+| network\_project\_id | Network GCP project to use. Defaults to `var.project_id`. | `string` | `null` | no |
+| network\_region | Network region. Defaults to `var.region`. | `string` | `null` | no |
+| notification\_sender\_email | Email address to send notifications to. | `string` | n/a | yes |
+| project\_id | GCP Project ID | `string` | n/a | yes |
 | random\_suffix | Add random suffix to deployed resources (to allow multiple deployments per project) | `string` | `true` | no |
 | region | GCP Region | `string` | `"us-east1"` | no |
 | report\_usage | Report anonymous usage to our analytics to improve the tool. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ Functional examples are included in the
 
 | Name | Description |
 |------|-------------|
-| cloud\_build\_worker\_pool | Cloud Build worker pool. |
 | cloud\_db\_uri | Database connection URI. |
-| migrate\_image | Docker image (with tag) for the controller service. |
-| migrate\_sql\_conn\_name | Database instance connection name. |
 | project\_id | GCP Project ID |
 | region | Region used to deploy CRMint. |
 | report\_usage\_id | Report Usage ID (empty if opt-out) |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "crmint" {
 
   app_title                 = "My Local Custom App"
   notification_sender_email = "me@example.com"
-  
+
   # Google Cloud Platform.
   project_id                = "YOUR_PROJECT_ID"
   region                    = "GCP_REGION"  # e.g. us-east1

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Functional examples are included in the
 | database\_tier | Database instance machine tier. Defaults to a small instance. | `string` | `"db-g1-small"` | no |
 | database\_user | Database user name. | `string` | `"crmintapp"` | no |
 | frontend\_image | Docker image uri (with tag) for the frontend service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"` | no |
-| iap\_allowed\_users | n/a | `list` | n/a | yes |
+| goog\_bc\_deployment\_name | This is only set if run via BC/CM | `string` | `""` | no |
+| iap\_allowed\_users | n/a | `list(any)` | n/a | yes |
 | iap\_brand\_id | Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`). | `any` | `null` | no |
 | iap\_support\_email | Support email used for configuring IAP | `any` | n/a | yes |
 | jobs\_image | Docker image uri (with tag) for the jobs service | `string` | `"europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"` | no |
@@ -93,6 +94,7 @@ Functional examples are included in the
 | network\_region | Network region. Defaults to `var.region`. | `any` | `null` | no |
 | notification\_sender\_email | Email address to send notifications to. | `any` | n/a | yes |
 | project\_id | GCP Project ID | `any` | n/a | yes |
+| random\_suffix | Add random suffix to deployed resources (to allow multiple deployments per project) | `string` | `true` | no |
 | region | GCP Region | `string` | `"us-east1"` | no |
 | report\_usage | Report anonymous usage to our analytics to improve the tool. | `bool` | `false` | no |
 | use\_vpc | Configures the database with a private IP. Default to true. | `bool` | `true` | no |

--- a/alerts.tf
+++ b/alerts.tf
@@ -36,8 +36,8 @@ resource "google_logging_metric" "pipeline_status_failed" {
     display_name = "Pipeline Status Failed Metric"
   }
   label_extractors = {
-    "pipeline_id"     = "EXTRACT(jsonPayload.labels.pipeline_id)"
-    "message"         = "EXTRACT(jsonPayload.message)"
+    "pipeline_id" = "EXTRACT(jsonPayload.labels.pipeline_id)"
+    "message"     = "EXTRACT(jsonPayload.message)"
   }
 
   depends_on = [google_project_service.apis]
@@ -62,10 +62,10 @@ resource "google_monitoring_alert_policy" "notify_on_pipeline_status_failed" {
   conditions {
     display_name = "Monitor pipeline errors"
     condition_threshold {
-      filter               = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.pipeline_status_failed.id}\" AND resource.type=cloud_run_revision"
-      duration             = "60s"
-      comparison           = "COMPARISON_GT"
-      threshold_value      = 0.001
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.pipeline_status_failed.id}\" AND resource.type=cloud_run_revision"
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0.001
       trigger {
         count = 1
       }

--- a/apis.tf
+++ b/apis.tf
@@ -46,7 +46,7 @@ resource "google_project_service" "apis" {
 }
 
 resource "google_project_service" "vpcaccess" {
-  count = var.use_vpc ? 1 : 0
+  count    = var.use_vpc ? 1 : 0
   provider = google-beta
 
   project = var.network_project_id != null ? var.network_project_id : var.project_id

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -37,16 +37,16 @@ steps:
 
 - id: disable_vpc-init
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n 's/.*@\(.*\).iam.gserviceaccount.com/\1/p') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format='value(name)' | sed 's:.*/::') && cft test run TestDisableVPC --stage init --verbose']
+  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n ''s/.*@\(.*\).iam.gserviceaccount.com/\1/p'') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format=''value(name)'' | sed ''s:.*/::'') && cft test run TestDisableVPC --stage init --verbose']
 - id: disable_vpc-apply
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n 's/.*@\(.*\).iam.gserviceaccount.com/\1/p') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format='value(name)' | sed 's:.*/::') && cft test run TestDisableVPC --stage apply --verbose']
+  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n ''s/.*@\(.*\).iam.gserviceaccount.com/\1/p'') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format=''value(name)'' | sed ''s:.*/::'') && cft test run TestDisableVPC --stage apply --verbose']
 - id: disable_vpc-verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n 's/.*@\(.*\).iam.gserviceaccount.com/\1/p') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format='value(name)' | sed 's:.*/::') && cft test run TestDisableVPC --stage verify --verbose']
+  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n ''s/.*@\(.*\).iam.gserviceaccount.com/\1/p'') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format=''value(name)'' | sed ''s:.*/::'') && cft test run TestDisableVPC --stage verify --verbose']
 - id: disable_vpc-teardown
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n 's/.*@\(.*\).iam.gserviceaccount.com/\1/p') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format='value(name)' | sed 's:.*/::') && cft test run TestDisableVPC --stage teardown --verbose']
+  args: ['/bin/bash', '-c', 'export PROJECT_ID=$(gcloud config get core/account | sed -n ''s/.*@\(.*\).iam.gserviceaccount.com/\1/p'') && gcloud services enable iap.googleapis.com --project $PROJECT_ID && export TF_VAR_iap_brand_id=$(gcloud iap oauth-brands list --project $PROJECT_ID --format=''value(name)'' | sed ''s:.*/::'') && cft test run TestDisableVPC --stage teardown --verbose']
 
 tags:
 - 'ci'

--- a/databases.tf
+++ b/databases.tf
@@ -21,7 +21,7 @@ locals {
 resource "google_sql_database_instance" "main" {
   deletion_protection = false
 
-  name        = var.random_suffix ? "${var.database_instance_name}-${random_id.suffix.hex}" : var.database_instance_name
+  name = var.random_suffix ? "${var.database_instance_name}-${random_id.suffix.hex}" : var.database_instance_name
 
   database_version = "MYSQL_8_0"
   project          = var.database_project_id != null ? var.database_project_id : var.project_id
@@ -43,7 +43,7 @@ resource "google_sql_database_instance" "main" {
       # Includes this block only if `local.private_network` is set to a non-null value.
       for_each = local.private_network[*]
       content {
-        ipv4_enabled = false
+        ipv4_enabled    = false
         private_network = local.private_network.id
       }
     }

--- a/examples/disable_vpc/README.md
+++ b/examples/disable_vpc/README.md
@@ -11,7 +11,6 @@ This example illustrates how to use the `crmint` module wihtout the VPC feature.
 | iap\_brand\_id | Existing IAP Brand ID. | `any` | `null` | no |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 | region | GCP Region | `string` | `"us-east1"` | no |
-| zone | GCP Zone | `string` | `"us-east1-c"` | no |
 
 ## Outputs
 

--- a/examples/disable_vpc/main.tf
+++ b/examples/disable_vpc/main.tf
@@ -22,21 +22,21 @@ module "crmint" {
   notification_sender_email = var.caller_identity
 
   # Google Cloud Platform.
-  project_id                = var.project_id
-  region                    = var.region  # e.g. us-east1
-  database_instance_name    = "crmint-3-db"
-  use_vpc                   = false
+  project_id             = var.project_id
+  region                 = var.region # e.g. us-east1
+  database_instance_name = "crmint-3-db"
+  use_vpc                = false
 
   # Docker service images (in case you want to pin to a specific version).
-  frontend_image            = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
-  controller_image          = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
-  jobs_image                = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
+  frontend_image   = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
+  controller_image = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
+  jobs_image       = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
 
   # User access management.
-  iap_brand_id              = var.iap_brand_id
-  iap_support_email         = var.caller_identity
-  iap_allowed_users         = [
-                                "serviceAccount:${var.caller_identity}",
-                                # "user:me@example.com",
-                              ]
+  iap_brand_id      = var.iap_brand_id
+  iap_support_email = var.caller_identity
+  iap_allowed_users = [
+    "serviceAccount:${var.caller_identity}",
+    # "user:me@example.com",
+  ]
 }

--- a/examples/disable_vpc/variables.tf
+++ b/examples/disable_vpc/variables.tf
@@ -24,11 +24,6 @@ variable "region" {
   default     = "us-east1"
 }
 
-variable "zone" {
-  description = "GCP Zone"
-  default     = "us-east1-c"
-}
-
 variable "caller_identity" {
   description = "Email of the caller, used to configure IAP."
 }

--- a/examples/disable_vpc/variables.tf
+++ b/examples/disable_vpc/variables.tf
@@ -21,12 +21,12 @@ variable "project_id" {
 
 variable "region" {
   description = "GCP Region"
-  default = "us-east1"
+  default     = "us-east1"
 }
 
 variable "zone" {
   description = "GCP Zone"
-  default = "us-east1-c"
+  default     = "us-east1-c"
 }
 
 variable "caller_identity" {

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -11,7 +11,6 @@ This example illustrates how to use the `crmint` module.
 | iap\_brand\_id | Existing IAP Brand ID. | `any` | `null` | no |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 | region | GCP Region | `string` | `"us-east1"` | no |
-| zone | GCP Zone | `string` | `"us-east1-c"` | no |
 
 ## Outputs
 

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -22,21 +22,21 @@ module "crmint" {
   notification_sender_email = var.caller_identity
 
   # Google Cloud Platform.
-  project_id                = var.project_id
-  region                    = var.region  # e.g. us-east1
-  database_instance_name    = "crmint-3-db"
-  use_vpc                   = true
+  project_id             = var.project_id
+  region                 = var.region # e.g. us-east1
+  database_instance_name = "crmint-3-db"
+  use_vpc                = true
 
   # Docker service images (in case you want to pin to a specific version).
-  frontend_image            = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
-  controller_image          = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
-  jobs_image                = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
+  frontend_image   = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
+  controller_image = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
+  jobs_image       = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
 
   # User access management.
-  iap_brand_id              = var.iap_brand_id
-  iap_support_email         = var.caller_identity
-  iap_allowed_users         = [
-                                "serviceAccount:${var.caller_identity}",
-                                # "user:me@example.com",
-                              ]
+  iap_brand_id      = var.iap_brand_id
+  iap_support_email = var.caller_identity
+  iap_allowed_users = [
+    "serviceAccount:${var.caller_identity}",
+    # "user:me@example.com",
+  ]
 }

--- a/examples/standard/variables.tf
+++ b/examples/standard/variables.tf
@@ -24,11 +24,6 @@ variable "region" {
   default     = "us-east1"
 }
 
-variable "zone" {
-  description = "GCP Zone"
-  default     = "us-east1-c"
-}
-
 variable "caller_identity" {
   description = "Email of the caller, used to configure IAP."
 }

--- a/examples/standard/variables.tf
+++ b/examples/standard/variables.tf
@@ -21,12 +21,12 @@ variable "project_id" {
 
 variable "region" {
   description = "GCP Region"
-  default = "us-east1"
+  default     = "us-east1"
 }
 
 variable "zone" {
   description = "GCP Zone"
-  default = "us-east1-c"
+  default     = "us-east1-c"
 }
 
 variable "caller_identity" {

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -201,7 +201,7 @@ locals {
   }
 }
 
-resource "google_cloud_run_service_iam_member" "frontend_run-invoker" {
+resource "google_cloud_run_service_iam_member" "frontend_run_invoker" {
   for_each = local.run_users
 
   location = google_cloud_run_service.frontend_run.location
@@ -211,7 +211,7 @@ resource "google_cloud_run_service_iam_member" "frontend_run-invoker" {
   member   = each.value
 }
 
-resource "google_cloud_run_service_iam_member" "controller_run-invoker" {
+resource "google_cloud_run_service_iam_member" "controller_run_invoker" {
   for_each = local.run_users
 
   location = google_cloud_run_service.controller_run.location
@@ -221,7 +221,7 @@ resource "google_cloud_run_service_iam_member" "controller_run-invoker" {
   member   = each.value
 }
 
-resource "google_cloud_run_service_iam_member" "jobs_run-invoker" {
+resource "google_cloud_run_service_iam_member" "jobs_run_invoker" {
   for_each = local.run_users
 
   location = google_cloud_run_service.jobs_run.location

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -157,8 +157,7 @@ resource "google_project_iam_member" "pubsub_token-creator" {
 ##
 # Cloud Run permissions
 #
-# NOTE: We delegate the authentication flow to IAP, so we need to give `allUsers` access
-#       to Cloud Run since it's not responsible anymore for authenticating the users.
+# NOTE: We delegate the authentication flow to IAP.
 #
 
 data "google_iam_policy" "iap_users" {
@@ -189,26 +188,33 @@ resource "google_iap_web_backend_service_iam_policy" "jobs" {
   policy_data = data.google_iam_policy.iap_users.policy_data
 }
 
-resource "google_cloud_run_service_iam_binding" "frontend_run-invoker" {
+data "google_iam_policy" "run_users" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+        "serviceAccount:${google_project_service_identity.iap_sa.email}",
+        "serviceAccount:${google_service_account.pubsub_sa.email}",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "frontend_run-invoker" {
   location = google_cloud_run_service.frontend_run.location
   project = google_cloud_run_service.frontend_run.project
   service = google_cloud_run_service.frontend_run.name
-  role = "roles/run.invoker"
-  members = ["allUsers"]
+  policy_data = data.google_iam_policy.run_users.policy_data
 }
 
-resource "google_cloud_run_service_iam_binding" "controller_run-invoker" {
+resource "google_cloud_run_service_iam_policy" "controller_run-invoker" {
   location = google_cloud_run_service.controller_run.location
   project = google_cloud_run_service.controller_run.project
   service = google_cloud_run_service.controller_run.name
-  role = "roles/run.invoker"
-  members = ["allUsers"]
+  policy_data = data.google_iam_policy.run_users.policy_data
 }
 
-resource "google_cloud_run_service_iam_binding" "jobs_run-invoker" {
+resource "google_cloud_run_service_iam_policy" "jobs_run-invoker" {
   location = google_cloud_run_service.jobs_run.location
   project = google_cloud_run_service.jobs_run.project
   service = google_cloud_run_service.jobs_run.name
-  role = "roles/run.invoker"
-  members = ["allUsers"]
+  policy_data = data.google_iam_policy.run_users.policy_data
 }

--- a/identity_aware_proxy.tf
+++ b/identity_aware_proxy.tf
@@ -36,9 +36,3 @@ resource "google_project_service_identity" "iap_sa" {
   project  = google_project_service.iap_service.project
   service  = "iap.googleapis.com"
 }
-
-resource "google_project_iam_member" "iap_sa--run_invoker" {
-  project = google_project_service.iap_service.project
-  role    = "roles/run.invoker"
-  member  = "serviceAccount:${google_project_service_identity.iap_sa.email}"
-}

--- a/identity_aware_proxy.tf
+++ b/identity_aware_proxy.tf
@@ -28,7 +28,7 @@ resource "google_iap_brand" "default" {
 
 resource "google_iap_client" "default" {
   display_name = "Test Client"
-  brand        =  var.iap_brand_id == null ? google_iap_brand.default[0].name : "projects/${var.project_id}/brands/${var.iap_brand_id}"
+  brand        = var.iap_brand_id == null ? google_iap_brand.default[0].name : "projects/${var.project_id}/brands/${var.iap_brand_id}"
 }
 
 resource "google_project_service_identity" "iap_sa" {

--- a/network.tf
+++ b/network.tf
@@ -65,7 +65,7 @@ resource "google_compute_backend_service" "frontend_backend" {
   }
 
   iap {
-    oauth2_client_id = google_iap_client.default.client_id
+    oauth2_client_id     = google_iap_client.default.client_id
     oauth2_client_secret = google_iap_client.default.secret
   }
 
@@ -85,7 +85,7 @@ resource "google_compute_backend_service" "controller_backend" {
   }
 
   iap {
-    oauth2_client_id = google_iap_client.default.client_id
+    oauth2_client_id     = google_iap_client.default.client_id
     oauth2_client_secret = google_iap_client.default.secret
   }
 
@@ -105,7 +105,7 @@ resource "google_compute_backend_service" "jobs_backend" {
   }
 
   iap {
-    oauth2_client_id = google_iap_client.default.client_id
+    oauth2_client_id     = google_iap_client.default.client_id
     oauth2_client_secret = google_iap_client.default.secret
   }
 
@@ -117,7 +117,7 @@ resource "google_compute_url_map" "default" {
   name        = var.random_suffix ? "crmint-http-lb-${random_id.suffix.hex}" : "crmint-http-lb"
   description = "Managed by ${local.managed_by_desc}"
 
-  default_service  = google_compute_backend_service.frontend_backend.id
+  default_service = google_compute_backend_service.frontend_backend.id
 
   host_rule {
     hosts        = ["*"]
@@ -125,17 +125,17 @@ resource "google_compute_url_map" "default" {
   }
 
   path_matcher {
-    name = "allpaths"
+    name            = "allpaths"
     default_service = google_compute_backend_service.frontend_backend.id
 
     path_rule {
       service = google_compute_backend_service.jobs_backend.id
-      paths = ["/api/workers", "/api/workers/*", "/push/start-task"]
+      paths   = ["/api/workers", "/api/workers/*", "/push/start-task"]
     }
 
     path_rule {
       service = google_compute_backend_service.controller_backend.id
-      paths = ["/api/*", "/push/task-finished", "/push/start-pipeline"]
+      paths   = ["/api/*", "/push/task-finished", "/push/start-pipeline"]
     }
   }
 }
@@ -154,11 +154,11 @@ resource "google_compute_global_forwarding_rule" "default" {
   name        = var.random_suffix ? "crmint-default-https-lb-forwarding-rule-${random_id.suffix.hex}" : "crmint-default-https-lb-forwarding-rule"
   description = "Managed by ${local.managed_by_desc}"
 
-  ip_protocol = "TCP"
+  ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
-  port_range = "443"
-  target = google_compute_target_https_proxy.default.id
-  ip_address = google_compute_global_address.default.id
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.default.id
+  ip_address            = google_compute_global_address.default.id
 }
 
 ##
@@ -166,7 +166,7 @@ resource "google_compute_global_forwarding_rule" "default" {
 
 resource "google_compute_network" "private" {
   provider = google-beta
-  count = var.use_vpc ? 1 : 0
+  count    = var.use_vpc ? 1 : 0
 
   name        = var.random_suffix ? "crmint-private-network-${random_id.suffix.hex}" : "crmint-private-network"
   description = "Managed by ${local.managed_by_desc}"
@@ -174,7 +174,7 @@ resource "google_compute_network" "private" {
   project                 = var.network_project_id != null ? var.network_project_id : var.project_id
   routing_mode            = "REGIONAL"
   mtu                     = 1460
-  auto_create_subnetworks = false  # Custom Subnet Mode
+  auto_create_subnetworks = false # Custom Subnet Mode
 
   # Create a network only if the compute.googleapis.com API has been activated.
   depends_on = [google_project_service.apis]
@@ -182,7 +182,7 @@ resource "google_compute_network" "private" {
 
 resource "google_compute_global_address" "db_private_ip_address" {
   provider = google-beta
-  count = var.use_vpc ? 1 : 0
+  count    = var.use_vpc ? 1 : 0
 
   name        = var.random_suffix ? "crmint-db-private-ip-address-${random_id.suffix.hex}" : "crmint-db-private-ip-address"
   description = "Managed by ${local.managed_by_desc}"
@@ -197,7 +197,7 @@ resource "google_compute_global_address" "db_private_ip_address" {
 
 resource "google_service_networking_connection" "private_vpc_connection" {
   provider = google-beta
-  count = var.use_vpc ? 1 : 0
+  count    = var.use_vpc ? 1 : 0
 
   network                 = google_compute_network.private[count.index].id
   service                 = "servicenetworking.googleapis.com"
@@ -216,19 +216,19 @@ resource "google_compute_subnetwork" "private" {
 }
 
 resource "google_vpc_access_connector" "connector" {
-  provider       = google-beta
-  count = var.use_vpc ? 1 : 0
+  provider = google-beta
+  count    = var.use_vpc ? 1 : 0
 
-  name        = var.random_suffix ? "crmint-vpc-conn-${random_id.suffix.hex}" : "crmint-vpc-conn"
+  name = var.random_suffix ? "crmint-vpc-conn-${random_id.suffix.hex}" : "crmint-vpc-conn"
 
-  machine_type   = "e2-micro"
-  max_instances  = 3
-  min_instances  = 2
-  project        = var.network_project_id != null ? var.network_project_id : var.project_id
-  region         = var.network_region != null ? var.network_region : var.region
+  machine_type  = "e2-micro"
+  max_instances = 3
+  min_instances = 2
+  project       = var.network_project_id != null ? var.network_project_id : var.project_id
+  region        = var.network_region != null ? var.network_region : var.region
 
   subnet {
-    name = google_compute_subnetwork.private[count.index].name
+    name       = google_compute_subnetwork.private[count.index].name
     project_id = var.network_project_id != null ? var.network_project_id : var.project_id
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,25 +29,10 @@ output "region" {
   description = "Region used to deploy CRMint."
 }
 
-output "migrate_image" {
-  value       = local.migrate_image
-  description = "Docker image (with tag) for the controller service."
-}
-
-output "migrate_sql_conn_name" {
-  value       = local.migrate_sql_conn_name
-  description = "Database instance connection name."
-}
-
 output "cloud_db_uri" {
   value       = local.cloud_db_uri
   description = "Database connection URI."
   sensitive   = true
-}
-
-output "cloud_build_worker_pool" {
-  value       = local.pool
-  description = "Cloud Build worker pool."
 }
 
 output "report_usage_id" {

--- a/pubsub.tf
+++ b/pubsub.tf
@@ -17,21 +17,21 @@
 locals {
   subscriptions = {
     "crmint-3-start-task" = {
-      "endpoint" = "${google_cloud_run_service.jobs_run.status[0].url}/push/start-task",
+      "endpoint"             = "${google_cloud_run_service.jobs_run.status[0].url}/push/start-task",
       "ack_deadline_seconds" = 600,
-      "minimum_backoff" = 60,  # seconds
+      "minimum_backoff"      = 60, # seconds
     }
 
     "crmint-3-task-finished" = {
-      "endpoint" = "${google_cloud_run_service.controller_run.status[0].url}/push/task-finished",
+      "endpoint"             = "${google_cloud_run_service.controller_run.status[0].url}/push/task-finished",
       "ack_deadline_seconds" = 60,
-      "minimum_backoff" = 10,  # seconds
+      "minimum_backoff"      = 10, # seconds
     }
 
     "crmint-3-start-pipeline" = {
-      "endpoint" = "${google_cloud_run_service.controller_run.status[0].url}/push/start-pipeline",
+      "endpoint"             = "${google_cloud_run_service.controller_run.status[0].url}/push/start-pipeline",
       "ack_deadline_seconds" = 60,
-      "minimum_backoff" = 10,  # seconds
+      "minimum_backoff"      = 10, # seconds
     }
   }
 }
@@ -39,15 +39,15 @@ locals {
 resource "google_pubsub_topic" "topics" {
   for_each = local.subscriptions
 
-  name        = var.random_suffix ? "${each.key}-${random_id.suffix.hex}" : each.key
-  labels      = var.labels
+  name   = var.random_suffix ? "${each.key}-${random_id.suffix.hex}" : each.key
+  labels = var.labels
 
-  depends_on  = [google_project_service.apis]
+  depends_on = [google_project_service.apis]
 }
 
 resource "google_pubsub_topic" "pipeline_finished" {
-  name        = var.random_suffix ? "crmint-3-pipeline-finished-${random_id.suffix.hex}" : "crmint-3-pipeline-finished"
-  labels      = var.labels
+  name   = var.random_suffix ? "crmint-3-pipeline-finished-${random_id.suffix.hex}" : "crmint-3-pipeline-finished"
+  labels = var.labels
 
   depends_on = [google_project_service.apis]
 }
@@ -59,13 +59,13 @@ resource "random_id" "pubsub_verification_token" {
 resource "google_pubsub_subscription" "subscriptions" {
   for_each = local.subscriptions
 
-  labels      = var.labels
-  name        = var.random_suffix ? "${each.key}-subscription-${random_id.suffix.hex}" : "${each.key}-subscription"
-  topic       = lookup(google_pubsub_topic.topics, each.key).id
+  labels = var.labels
+  name   = var.random_suffix ? "${each.key}-subscription-${random_id.suffix.hex}" : "${each.key}-subscription"
+  topic  = lookup(google_pubsub_topic.topics, each.key).id
 
   ack_deadline_seconds = each.value.ack_deadline_seconds
   expiration_policy {
-    ttl = ""  # Stands for "never".
+    ttl = "" # Stands for "never".
   }
   retry_policy {
     minimum_backoff = "${each.value.minimum_backoff}s"

--- a/schedulers.tf
+++ b/schedulers.tf
@@ -18,8 +18,8 @@ resource "google_cloud_scheduler_job" "heartbeat" {
   name        = var.random_suffix ? "crmint-heartbeat-${random_id.suffix.hex}" : "crmint-heartbeat"
   description = "Triggers scheduled pipeline runs - Managed by ${local.managed_by_desc}"
 
-  schedule    = "* * * * *"
-  project     = var.project_id
+  schedule = "* * * * *"
+  project  = var.project_id
 
   pubsub_target {
     topic_name = lookup(google_pubsub_topic.topics, "crmint-3-start-pipeline").id

--- a/services.tf
+++ b/services.tf
@@ -61,7 +61,7 @@ resource "google_cloud_run_service" "frontend_run" {
   # Avoids a redeploy each time "run.googleapis.com/operation-id" changes.
   lifecycle {
     ignore_changes = [
-      metadata.0.annotations,
+      metadata[0].annotations,
     ]
   }
 
@@ -201,7 +201,7 @@ resource "google_cloud_run_service" "controller_run" {
   # Avoids a redeploy each time "run.googleapis.com/operation-id" changes.
   lifecycle {
     ignore_changes = [
-      metadata.0.annotations,
+      metadata[0].annotations,
     ]
   }
 
@@ -277,7 +277,7 @@ resource "google_cloud_run_service" "jobs_run" {
   # Avoids a redeploy each time "run.googleapis.com/operation-id" changes.
   lifecycle {
     ignore_changes = [
-      metadata.0.annotations,
+      metadata[0].annotations,
     ]
   }
 

--- a/services.tf
+++ b/services.tf
@@ -283,37 +283,3 @@ resource "google_cloud_run_service" "jobs_run" {
 
   depends_on = [google_project_service.apis]
 }
-
-resource "google_cloudbuild_worker_pool" "private" {
-  count = var.use_vpc ? 1 : 0
-
-  name = "crmint-private-pool"
-  location = var.region
-
-  worker_config {
-    disk_size_gb = 100
-    machine_type = "e2-standard-2"
-    no_external_ip = var.use_vpc ? true : false
-  }
-
-  dynamic "network_config" {
-    # Includes this block only if `local.private_network` is set to a non-null value.
-    for_each = local.private_network[*]
-    content {
-      peered_network = google_compute_network.private[0].id
-    }
-  }
-
-  depends_on = [
-    google_project_service.apis,
-    google_project_service.vpcaccess,
-    google_service_networking_connection.private_vpc_connection
-  ]
-}
-
-# Local variables are used to simplify the definition of outputs.
-locals {
-  migrate_image = var.controller_image
-  migrate_sql_conn_name = google_sql_database_instance.main.connection_name
-  pool = var.use_vpc ? google_cloudbuild_worker_pool.private[0].id : "default"
-}

--- a/services.tf
+++ b/services.tf
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "cloud_db_uri" {
 }
 
 resource "google_secret_manager_secret_version" "cloud_db_uri-latest" {
-  secret = google_secret_manager_secret.cloud_db_uri.name
+  secret      = google_secret_manager_secret.cloud_db_uri.name
   secret_data = local.cloud_db_uri
 }
 
@@ -130,7 +130,7 @@ resource "google_cloud_run_service" "controller_run" {
           "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector[0].name
           # Routes only egress to private ip addresses through the VPC Connector.
           "run.googleapis.com/vpc-access-egress" = "private-ranges-only"
-        } : {
+          } : {
           "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.main.connection_name
         }
       )
@@ -179,11 +179,11 @@ resource "google_cloud_run_service" "controller_run" {
           value = random_id.pubsub_verification_token.b64_url
         }
         env {
-          name  = "DATABASE_URI"
+          name = "DATABASE_URI"
           value_from {
             secret_key_ref {
               name = google_secret_manager_secret.cloud_db_uri.secret_id
-              key = "latest"
+              key  = "latest"
             }
           }
         }
@@ -263,7 +263,7 @@ resource "google_cloud_run_service" "jobs_run" {
         }
       }
 
-      timeout_seconds = 900  # 15min
+      timeout_seconds = 900 # 15min
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,7 @@
 variable "report_usage" {
   description = "Report anonymous usage to our analytics to improve the tool."
   default     = false
+  type        = bool
 }
 
 
@@ -29,10 +30,12 @@ variable "report_usage" {
 variable "app_title" {
   description = "Project name to display in the UI."
   default     = "CRMint App"
+  type        = string
 }
 
 variable "notification_sender_email" {
   description = "Email address to send notifications to."
+  type        = string
 }
 
 
@@ -42,14 +45,16 @@ variable "notification_sender_email" {
 variable "iap_brand_id" {
   description = "Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`)."
   default     = null
+  type        = string
 }
 
 variable "iap_support_email" {
   description = "Support email used for configuring IAP"
+  type        = string
 }
 
 variable "iap_allowed_users" {
-  type = list(any)
+  type = list(string)
 }
 
 
@@ -58,11 +63,13 @@ variable "iap_allowed_users" {
 
 variable "project_id" {
   description = "GCP Project ID"
+  type        = string
 }
 
 variable "region" {
   description = "GCP Region"
   default     = "us-east1"
+  type        = string
 }
 
 
@@ -72,16 +79,19 @@ variable "region" {
 variable "use_vpc" {
   description = "Configures the database with a private IP. Default to true."
   default     = true
+  type        = bool
 }
 
 variable "network_project_id" {
   description = "Network GCP project to use. Defaults to `var.project_id`."
   default     = null
+  type        = string
 }
 
 variable "network_region" {
   description = "Network region. Defaults to `var.region`."
   default     = null
+  type        = string
 }
 
 
@@ -91,36 +101,43 @@ variable "network_region" {
 variable "database_project_id" {
   description = "Database GCP project to use. Defaults to `var.project_id`."
   default     = null
+  type        = string
 }
 
 variable "database_region" {
   description = "Database region to setup a Cloud SQL instance. Defaults to `var.region`"
   default     = null
+  type        = string
 }
 
 variable "database_tier" {
   description = "Database instance machine tier. Defaults to a small instance."
   default     = "db-g1-small"
+  type        = string
 }
 
 variable "database_availability_type" {
   description = "Database availability type. Defaults to one zone."
   default     = "ZONAL"
+  type        = string
 }
 
 variable "database_instance_name" {
   description = "Name for the Cloud SQL instance."
   default     = "crmint-3-db"
+  type        = string
 }
 
 variable "database_name" {
   description = "Name of the database in your Cloud SQL instance."
   default     = "crmintapp-db"
+  type        = string
 }
 
 variable "database_user" {
   description = "Database user name."
   default     = "crmintapp"
+  type        = string
 }
 
 
@@ -130,16 +147,19 @@ variable "database_user" {
 variable "frontend_image" {
   description = "Docker image uri (with tag) for the frontend service"
   default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
+  type        = string
 }
 
 variable "controller_image" {
   description = "Docker image uri (with tag) for the controller service"
   default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
+  type        = string
 }
 
 variable "jobs_image" {
   description = "Docker image uri (with tag) for the jobs service"
   default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
+  type        = string
 }
 
 
@@ -148,14 +168,14 @@ variable "jobs_image" {
 
 variable "random_suffix" {
   description = "Add random suffix to deployed resources (to allow multiple deployments per project)"
-  type        = string
   default     = true
+  type        = string
 }
 
 variable "goog_bc_deployment_name" {
   description = "This is only set if run via BC/CM"
-  type        = string
   default     = ""
+  type        = string
 }
 
 variable "labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "notification_sender_email" {
 
 variable "iap_brand_id" {
   description = "Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`)."
-  default = null
+  default     = null
 }
 
 variable "iap_support_email" {
@@ -49,7 +49,7 @@ variable "iap_support_email" {
 }
 
 variable "iap_allowed_users" {
-  type = list
+  type = list(any)
 }
 
 
@@ -62,7 +62,7 @@ variable "project_id" {
 
 variable "region" {
   description = "GCP Region"
-  default = "us-east1"
+  default     = "us-east1"
 }
 
 
@@ -71,17 +71,17 @@ variable "region" {
 
 variable "use_vpc" {
   description = "Configures the database with a private IP. Default to true."
-  default = true
+  default     = true
 }
 
 variable "network_project_id" {
   description = "Network GCP project to use. Defaults to `var.project_id`."
-  default = null
+  default     = null
 }
 
 variable "network_region" {
   description = "Network region. Defaults to `var.region`."
-  default = null
+  default     = null
 }
 
 
@@ -90,37 +90,37 @@ variable "network_region" {
 
 variable "database_project_id" {
   description = "Database GCP project to use. Defaults to `var.project_id`."
-  default = null
+  default     = null
 }
 
 variable "database_region" {
   description = "Database region to setup a Cloud SQL instance. Defaults to `var.region`"
-  default = null
+  default     = null
 }
 
 variable "database_tier" {
   description = "Database instance machine tier. Defaults to a small instance."
-  default = "db-g1-small"
+  default     = "db-g1-small"
 }
 
 variable "database_availability_type" {
   description = "Database availability type. Defaults to one zone."
-  default = "ZONAL"
+  default     = "ZONAL"
 }
 
 variable "database_instance_name" {
   description = "Name for the Cloud SQL instance."
-  default = "crmint-3-db"
+  default     = "crmint-3-db"
 }
 
 variable "database_name" {
   description = "Name of the database in your Cloud SQL instance."
-  default = "crmintapp-db"
+  default     = "crmintapp-db"
 }
 
 variable "database_user" {
   description = "Database user name."
-  default = "crmintapp"
+  default     = "crmintapp"
 }
 
 
@@ -129,17 +129,17 @@ variable "database_user" {
 
 variable "frontend_image" {
   description = "Docker image uri (with tag) for the frontend service"
-  default = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
+  default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/frontend:master"
 }
 
 variable "controller_image" {
   description = "Docker image uri (with tag) for the controller service"
-  default = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
+  default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/controller:master"
 }
 
 variable "jobs_image" {
   description = "Docker image uri (with tag) for the jobs service"
-  default = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
+  default     = "europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/jobs:master"
 }
 
 
@@ -148,14 +148,14 @@ variable "jobs_image" {
 
 variable "random_suffix" {
   description = "Add random suffix to deployed resources (to allow multiple deployments per project)"
-  type = string
-  default = true
+  type        = string
+  default     = true
 }
 
 variable "goog_bc_deployment_name" {
   description = "This is only set if run via BC/CM"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,8 @@ variable "iap_support_email" {
 }
 
 variable "iap_allowed_users" {
-  type = list(string)
+  description = "List of user email addresses that should be allowed to use the CRMint UI"
+  type        = list(string)
 }
 
 

--- a/versions.tf
+++ b/versions.tf
@@ -18,15 +18,15 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "4.43.1"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = "4.43.1"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "3.4.3"
     }
   }


### PR DESCRIPTION
This update covers two things:
- No need for Private Workers Pool anymore since the reset functionality is now accessible from our UI.
- Cloud Run is now compatible with IAP without the need to add a permission to `allUsers`, we are taking advantage of that.

Cheers